### PR TITLE
Allow -f to take a value from the following argument

### DIFF
--- a/mini_sendmail.c
+++ b/mini_sendmail.c
@@ -15,7 +15,7 @@
 
 /* mini_sendmail - accept email on behalf of real sendmail
 **
-** Copyright © 1999,2015 by Jef Poskanzer <jef@mail.acme.com>.
+** Copyright Â© 1999,2015 by Jef Poskanzer <jef@mail.acme.com>.
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -144,6 +144,11 @@ main( int argc, char** argv )
 	{
 	if ( strncmp( argv[argn], "-f", 2 ) == 0 && argv[argn][2] != '\0' )
 	    fake_from = &(argv[argn][2]);
+	else if ( ( strcmp( argv[argn], "-f" ) == 0 ) && ( argn+1 < argc ) )
+	    {
+		argn++;
+		fake_from=argv[argn];
+	    }
 	else if ( strcmp( argv[argn], "-t" ) == 0 )
 	    parse_message = 1;
 #ifdef DO_MINUS_SP


### PR DESCRIPTION
This allows the -f option to take its value from the next command line argument, instead of requiring -f and the address to be run together into a single argument.  Real sendmail allows both syntaxes, and when MediaWiki invokes PHP's mail() function, it does it with the separate-argument syntax (so that unpatched mini_sendmail cannot be used for MediaWiki).  Unfortunately, even with this patch it still doesn't work in my MediaWiki installation, but adding the missing syntax at least removes one of the obstacles.